### PR TITLE
Additional info

### DIFF
--- a/src/MessageTests.js
+++ b/src/MessageTests.js
@@ -31,6 +31,8 @@ const regex = {
     getid: /^\-{1}\s*(\d+)|^\+{1}\s*(\d+)/,
     // Ends with the ex tag !EX
     withextag: /!ex$/i,
+    // With Additional text
+    withaddition: /[,]/,
     escape: /[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g,
 };
 

--- a/src/RaidBot.js
+++ b/src/RaidBot.js
@@ -313,6 +313,10 @@ class RaidBot {
         let msgTxt = msgObj.content.trim();
         let team = false;
 
+        if(MessageTests.is("withAddition",msgTxt)){
+            username += ` ${msgTxt.substr(msgTxt.indexOf(",") + 1)}`;
+        }
+
         if (MessageTests.is('withLevelHint', msgTxt)) {
             const lvlMatch = msgTxt.match(/\d+\s*$/i);
             if (lvlMatch) {


### PR DESCRIPTION
Adding the ability for extra info after a comma sign. 

It could be helpfull when people have multiple accounts with other levels then their account says.

Example:
+1, level 30