### PR TITLE
refactor to make the bot 'remoteraids' proof 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ $ node index.js
   * Create a raid: `++ [raid text]`
   * Join a raid: `+ [raid id]`
   * Join a raid on team Instinct: `+ [raid id] i`
+  * Join a raid with a level 12 acount: `+ [raid id] =12`
+  * Join a raid as remote player: `+ [raid id] r` or `+ [raid id] =r`
   * Leave a raid: `- [raid id]`
-  * Cancel a raid: `- cancel [raid id]`
-  * Uncancel a raid: `+ uncancel [raid id]`
+  * Cancel a raid: `- [raid id] cancel`
+  * Uncancel a raid: `+ [raid id] uncancel `
   * Edit raid text: `+ mod [raid text]`
+  * let other (remote) players know to join the lobby: `+ [raid id] start`

--- a/src/MessageTests.js
+++ b/src/MessageTests.js
@@ -10,11 +10,15 @@ const regex = {
     // Join raid is 1 plus sign and a number (id)
     joinraid: /^\+{1}\s*\d+/,
     // Join raid message has team hint
-    withteamhint: /^\+\s*\d+\s*(v|i|m)$/i,
+    withteamhint: /^\+\s*\d+\s*(v|i|m|r)$/i,
     // Join a raid with a level hint
-    withlevelhint: /\s*=\s*\d+\s*$/i,
+    withlevelhint: /\s*=\s*([0-9]|[0-5][0-9])\s*$/i,
+    // Join a raid with a remote hint
+    withremotehint: /\s*=\s*(r.*|i.*)\s*\.*$/i,
     // leave raid is 1 minus sign and a number (id) 
     leaveraid: /^\-{1}\s*\d+/,
+	// Inform people of the starttime
+    starttime: /^\+{1}\s*\d+\s*start/i,
     // Moderator input is plus sign a number and the word mod
     modbreak: /^\+{1}\s*\d+\s*mod/i,
     // Cleanup the overview channels

--- a/src/RaidLists.js
+++ b/src/RaidLists.js
@@ -105,6 +105,18 @@ class RaidLists {
         return true;
     }
 
+    starttime(id, userId) {
+        const raid = this.get(id);
+        if (!raid) {
+            return false;
+        }
+
+        raid.canceled = false;
+        raid.canceledBy = userId;
+
+        return true;
+    }
+
     unCancel(id) {
         const raid = this.get(id);
         if (!raid) {

--- a/src/RaidOverviews.js
+++ b/src/RaidOverviews.js
@@ -53,6 +53,18 @@ class RaidOverviews {
         });
     }
 
+    starttime(raidId) {
+        overviews.map(ch => {
+            ch.raids.map(r => {
+                if (r.raidId !== raidId) {
+                    return;
+                }
+
+                r.msg.edit(`${r.msg} **started**`);
+            });
+        });
+    }
+
     unCancel(raidId) {
         overviews.map(ch => {
             ch.raids.map(r => {

--- a/src/RaidStats.js
+++ b/src/RaidStats.js
@@ -155,7 +155,8 @@ class RaidStats {
             teamCounts: {
                 valor: 0,
                 instinct: 0,
-                mystic: 0
+                mystic: 0,
+                remote: 0
             },
             canceledRaids: 0,
         };


### PR DESCRIPTION
updated the bot so players can join as remote. I have made a few alterations to not only make it possible to join as remote raider, but send a message to everyone as well when you start the raid lobby. I added a counter for the maximun remote players as well, but this must be altered by hand when niantic changes it to 5. line 419 "re_counter: 10" in Raidbot.js